### PR TITLE
Fix Alpine bug with missing "theme" property, and lazy-load CSS/JS assets

### DIFF
--- a/src/FilamentSyntaxEntryServiceProvider.php
+++ b/src/FilamentSyntaxEntryServiceProvider.php
@@ -53,8 +53,8 @@ class FilamentSyntaxEntryServiceProvider extends PackageServiceProvider
     protected function getAssets(): array
     {
         return [
-            Css::make('filament-syntax-entry-styles', __DIR__ . '/../resources/dist/filament-syntax-entry.css'),
-            Js::make('filament-syntax-entry-scripts', __DIR__ . '/../resources/dist/filament-syntax-entry.js'),
+            Css::make('filament-syntax-entry-styles', __DIR__ . '/../resources/dist/filament-syntax-entry.css')->loadedOnRequest(),
+            Js::make('filament-syntax-entry-scripts', __DIR__ . '/../resources/dist/filament-syntax-entry.js')->loadedOnRequest(),
         ];
     }
 


### PR DESCRIPTION
Previously, they were being bundled regardless of the presence of the SyntaxEntry component.